### PR TITLE
use `Variables` to set a prisma client type instead of `ContextVariableMap`

### DIFF
--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -1,5 +1,5 @@
-import { } from 'hono'
-import { PrismaClient } from "@prisma/client"
+import {} from 'hono'
+import { PrismaClient } from '@prisma/client'
 
 type Head = {
   title?: string
@@ -7,16 +7,14 @@ type Head = {
 
 declare module 'hono' {
   interface Env {
-    Variables: {}
+    Variables: {
+      prisma: PrismaClient
+    }
     Bindings: {
       DB: D1Database
     }
   }
   interface ContextRenderer {
     (content: string | Promise<string>, head?: Head): Response | Promise<Response>
-  }
-
-  interface ContextVariableMap {
-    prisma: PrismaClient
   }
 }


### PR DESCRIPTION
Hey! It's better to use `Variables` to set a variable type instead of `ContextVariableMap`!